### PR TITLE
Update Bag-Size property in bag-info.txt

### DIFF
--- a/src/test/scala/nl/knaw/dans/bag/v0/DansV0BagSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/DansV0BagSpec.scala
@@ -2352,14 +2352,14 @@ class DansV0BagSpec extends TestSupportFixture
     bag.bagInfo should contain only(
       "Payload-Oxum" -> Seq("2592.7"),
       "Bagging-Date" -> Seq(today),
-      "Bag-Size" -> Seq("0.6 KB"),
+      "Bag-Size" -> Seq("2.5 KB"),
       "Created" -> Seq("2017-01-16T14:35:00.888+01:00"),
       "Is-Version-Of" -> Seq(uuid),
     )
     bag.baseDir should containInBagInfoOnly(
       "Payload-Oxum" -> Seq("2592.7"),
       "Bagging-Date" -> Seq(today),
-      "Bag-Size" -> Seq("0.6 KB"),
+      "Bag-Size" -> Seq("2.5 KB"),
       "Created" -> Seq("2017-01-16T14:35:00.888+01:00"),
       "Is-Version-Of" -> Seq(uuid)
     )


### PR DESCRIPTION
fixes #5

mainly copied from the code in [easy-split-multi-deposit](https://github.com/DANS-KNAW/easy-split-multi-deposit/blob/ea7c2dc3d6a78cacd779d2efcb2d799e399e22cf/src/main/scala/nl.knaw.dans.easy.multideposit/actions/AddBagToDeposit.scala#L65-L95)

@DANS-KNAW/easy for review