### PR TITLE
don't remove empty manifests when all payload files are removed

### DIFF
--- a/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
+++ b/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
@@ -291,7 +291,7 @@ class DansV0Bag private(private[v0] val locBag: LocBag) extends DansBag {
    */
   override def removeFetchItem(item: FetchItem): DansV0Bag = {
     if (locBag.getItemsToFetch.remove(FetchItem.locDeconverter(item)))
-      removeFileFromManifests(item.file, locBag.getPayLoadManifests, locBag.setPayLoadManifests)
+      removeFileFromManifests(item.file, locBag.getPayLoadManifests)
 
     if (locBag.getItemsToFetch.isEmpty) {
       val fetchFilePath = baseDir / "fetch.txt"
@@ -539,7 +539,7 @@ class DansV0Bag private(private[v0] val locBag: LocBag) extends DansBag {
       throw new IllegalArgumentException(s"cannot remove directory '$file'; you can only remove files")
 
     removeFile(file, data)
-    removeFileFromManifests(file, locBag.getPayLoadManifests, locBag.setPayLoadManifests)
+    removeFileFromManifests(file, locBag.getPayLoadManifests)
 
     this
   }
@@ -645,7 +645,7 @@ class DansV0Bag private(private[v0] val locBag: LocBag) extends DansBag {
       throw new IllegalArgumentException(s"cannot remove tagmanifest file '$file'")
 
     removeFile(file, baseDir)
-    removeFileFromManifests(file, locBag.getTagManifests, locBag.setTagManifests)
+    removeFileFromManifests(file, locBag.getTagManifests)
 
     this
   }
@@ -876,13 +876,10 @@ class DansV0Bag private(private[v0] val locBag: LocBag) extends DansBag {
     }
   }
 
-  private def removeFileFromManifests(file: File, manifests: jSet[LocManifest],
-                                      setManifests: jSet[LocManifest] => Unit): Unit = {
+  private def removeFileFromManifests(file: File, manifests: jSet[LocManifest]): Unit = {
     for (manifest <- manifests.asScala;
          fileChecksumMap = manifest.getFileToChecksumMap)
       fileChecksumMap.remove(file.path)
-
-    setManifests(manifests.asScala.toList.toSet.asJava)
   }
 
   private def calculateSizeOfPath(dir: File): Long = {

--- a/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
+++ b/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
@@ -882,11 +882,7 @@ class DansV0Bag private(private[v0] val locBag: LocBag) extends DansBag {
          fileChecksumMap = manifest.getFileToChecksumMap)
       fileChecksumMap.remove(file.path)
 
-    setManifests {
-      manifests.asScala.toList
-        .filterNot(_.getFileToChecksumMap.isEmpty)
-        .toSet.asJava
-    }
+    setManifests(manifests.asScala.toList.toSet.asJava)
   }
 
   private def calculateSizeOfPath(dir: File): Long = {

--- a/src/test/scala/nl/knaw/dans/bag/v0/ManifestSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/ManifestSpec.scala
@@ -318,7 +318,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
     inside(result) {
       case Success(resultBag) =>
-        resultBag.payloadManifests shouldBe empty
+        forEvery(List(ChecksumAlgorithm.SHA1, ChecksumAlgorithm.SHA256))(algo => {
+          resultBag.payloadManifests should contain key algo
+
+          resultBag.payloadManifests(algo) shouldBe empty
+        })
     }
   }
 


### PR DESCRIPTION
fixes #38

solution:
* empty payload manifests due to all files being removed are no longer deleted themselves (`DansBagV0`)
* adjusted an incorrect test (`ManifestSpec`)
* added an extra test on `.save()` (`SaveSpec`)