### PR TITLE
ScalaTest syntax 'file should exist' for better.files.File

### DIFF
--- a/src/test/scala/nl/knaw/dans/bag/fixtures/TestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/bag/fixtures/TestSupportFixture.scala
@@ -16,10 +16,14 @@
 package nl.knaw.dans.bag.fixtures
 
 import org.scalatest._
+import org.scalatest.enablers.Existence
 
 trait TestSupportFixture extends FlatSpec
   with Matchers
   with Inside
   with OptionValues
   with EitherValues
-  with Inspectors
+  with Inspectors {
+
+  implicit def existenceOfFile[FILE <: better.files.File]: Existence[FILE] = _.exists
+}

--- a/src/test/scala/nl/knaw/dans/bag/v0/FactoryMethodsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/FactoryMethodsSpec.scala
@@ -37,12 +37,12 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
       "Is-Version-Of" -> Seq(s"urn:uuid:${ UUID.randomUUID() }")
     )
 
-    baseDir.toJava shouldNot exist
+    baseDir shouldNot exist
 
     DansV0Bag.empty(baseDir, algorithms, bagInfo) shouldBe a[Success[_]]
 
-    baseDir.toJava should exist
-    (baseDir / "data").toJava should exist
+    baseDir should exist
+    (baseDir / "data") should exist
     (baseDir / "data").listRecursively.toList shouldBe empty
   }
 
@@ -53,11 +53,11 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
       "Is-Version-Of" -> Seq(s"urn:uuid:${ UUID.randomUUID() }")
     )
 
-    baseDir.toJava shouldNot exist
+    baseDir shouldNot exist
 
     DansV0Bag.empty(baseDir, algorithms, bagInfo) shouldBe a[Success[_]]
 
-    baseDir.toJava should exist
+    baseDir should exist
   }
 
   it should "create a bag-info.txt file if the given Map is empty, " +
@@ -67,7 +67,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
 
     DansV0Bag.empty(baseDir, algorithms) shouldBe a[Success[_]]
 
-    (baseDir / "bag-info.txt").toJava should exist
+    (baseDir / "bag-info.txt") should exist
 
     baseDir should containInBagInfoOnly(
       "Payload-Oxum" -> Seq("0.0"),
@@ -85,7 +85,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
 
     DansV0Bag.empty(baseDir, algorithms, bagInfo) shouldBe a[Success[_]]
 
-    (baseDir / "bag-info.txt").toJava should exist
+    (baseDir / "bag-info.txt") should exist
 
     baseDir should containInBagInfoOnly(
       "Payload-Oxum" -> Seq("0.0"),
@@ -105,7 +105,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
 
     DansV0Bag.empty(baseDir, algorithms, bagInfo) shouldBe a[Success[_]]
 
-    (baseDir / "bag-info.txt").toJava should exist
+    (baseDir / "bag-info.txt") should exist
 
     baseDir should containInBagInfoOnly(
       "Payload-Oxum" -> Seq("0.0"),
@@ -161,7 +161,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
   it should "fail when the base directory for the bag-to-be-created already exists" in {
     val baseDir = testDir / "emptyTestBag" createDirectories()
     baseDir / "x.txt" createIfNotExists() writeText lipsum(2)
-    baseDir.toJava should exist
+    baseDir should exist
 
     val algorithms = Set(ChecksumAlgorithm.SHA1, ChecksumAlgorithm.SHA512)
 
@@ -195,7 +195,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
       "Is-Version-Of" -> Seq(s"urn:uuid:${ UUID.randomUUID() }")
     )
 
-    baseDir.toJava should exist
+    baseDir should exist
     baseDir.listRecursively.filter(_.isRegularFile).toList should contain only(file1, file2)
 
     DansV0Bag.createFromData(baseDir, algorithms, bagInfo) shouldBe a[Success[_]]
@@ -203,8 +203,8 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
     val file1Data = baseDir / "data" / baseDir.relativize(file1).toString
     val file2Data = baseDir / "data" / baseDir.relativize(file2).toString
 
-    baseDir.toJava should exist
-    (baseDir / "data").toJava should exist
+    baseDir should exist
+    (baseDir / "data") should exist
     (baseDir / "data").listRecursively.filter(_.isRegularFile).toList should contain only(file1Data, file2Data)
     baseDir.list.filter(_.isRegularFile).toList should contain only(
       baseDir / "bagit.txt",
@@ -221,7 +221,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
 
     DansV0Bag.createFromData(baseDir, algorithms) shouldBe a[Success[_]]
 
-    (baseDir / "bag-info.txt").toJava should exist
+    (baseDir / "bag-info.txt") should exist
 
     baseDir should containInBagInfoOnly(
       "Payload-Oxum" -> Seq("1471.2"),
@@ -239,7 +239,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
 
     DansV0Bag.createFromData(baseDir, algorithms, bagInfo) shouldBe a[Success[_]]
 
-    (baseDir / "bag-info.txt").toJava should exist
+    (baseDir / "bag-info.txt") should exist
 
     baseDir should containInBagInfoOnly(
       "Payload-Oxum" -> Seq("1471.2"),
@@ -259,7 +259,7 @@ class FactoryMethodsSpec extends TestSupportFixture with TestBags with BagMatche
 
     DansV0Bag.createFromData(baseDir, algorithms, bagInfo) shouldBe a[Success[_]]
 
-    (baseDir / "bag-info.txt").toJava should exist
+    (baseDir / "bag-info.txt") should exist
 
     baseDir should containInBagInfoOnly(
       "Payload-Oxum" -> Seq("1471.2"),

--- a/src/test/scala/nl/knaw/dans/bag/v0/FetchItemSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/FetchItemSpec.scala
@@ -404,25 +404,25 @@ class FetchItemSpec extends TestSupportFixture
   "replaceFileWithFetchItem with RelativePath" should "remove the file from the payload" in {
     val bag = fetchBagV0()
 
-    (bag.data / "y").toJava should exist
+    (bag.data / "y") should exist
 
     inside(bag.replaceFileWithFetchItem(_ / "y", new URL("http://y"))) {
       case Success(resultBag) =>
-        (resultBag.data / "y").toJava shouldNot exist
+        (resultBag.data / "y") shouldNot exist
     }
   }
 
   it should "remove any empty directories that are left behind after removing the file from the payload" in {
     val bag = fetchBagV0()
 
-    (bag.data / "more" / "files" / "abc").toJava should exist
+    (bag.data / "more" / "files" / "abc") should exist
 
     inside(bag.replaceFileWithFetchItem(_ / "more" / "files" / "abc", new URL("http://abc"))) {
       case Success(resultBag) =>
-        (resultBag.data / "more" / "files" / "abc").toJava shouldNot exist
-        (resultBag.data / "more" / "files").toJava shouldNot exist
-        (resultBag.data / "more").toJava shouldNot exist
-        resultBag.data.toJava should exist
+        (resultBag.data / "more" / "files" / "abc") shouldNot exist
+        (resultBag.data / "more" / "files") shouldNot exist
+        (resultBag.data / "more") shouldNot exist
+        resultBag.data should exist
     }
   }
 
@@ -458,7 +458,7 @@ class FetchItemSpec extends TestSupportFixture
   it should "fail when the file does not exist in the payload manifest" in {
     val bag = fetchBagV0()
 
-    (bag.data / "no-such-file.txt").toJava shouldNot exist
+    (bag.data / "no-such-file.txt") shouldNot exist
 
     inside(bag.replaceFileWithFetchItem(_ / "no-such-file.txt", new URL("http://xxx"))) {
       case Failure(e: NoSuchFileException) =>
@@ -487,11 +487,11 @@ class FetchItemSpec extends TestSupportFixture
   "replaceFileWithFetchItem with java.nio.file.Path" should "forward to the overload with RelativePath" in {
     val bag = fetchBagV0()
 
-    (bag.data / "y").toJava should exist
+    (bag.data / "y") should exist
 
     inside(bag.replaceFileWithFetchItem(Paths.get("y"), new URL("http://y"))) {
       case Success(resultBag) =>
-        (resultBag.data / "y").toJava shouldNot exist
+        (resultBag.data / "y") shouldNot exist
     }
   }
 
@@ -501,11 +501,11 @@ class FetchItemSpec extends TestSupportFixture
     val bag = fetchBagV0()
     val x = bag.data / "x"
 
-    x.toJava shouldNot exist
+    x shouldNot exist
 
     inside(bag.replaceFetchItemWithFile(_ / "x")) {
       case Success(_) =>
-        x.toJava should exist
+        x should exist
     }
   }
 
@@ -524,11 +524,11 @@ class FetchItemSpec extends TestSupportFixture
     val bag = fetchBagV0()
     val x = bag.data / "x"
 
-    x.toJava shouldNot exist
+    x shouldNot exist
 
     inside(bag.replaceFetchItemWithFile(Paths.get("x"))) {
       case Success(_) =>
-        x.toJava should exist
+        x should exist
     }
   }
 
@@ -539,11 +539,11 @@ class FetchItemSpec extends TestSupportFixture
     val url = lipsum4URL
     val path = lipsum4Dest(bag.data)
 
-    path.toJava shouldNot exist
+    path shouldNot exist
 
     inside(bag.replaceFetchItemWithFile(url)) {
       case Success(_) =>
-        path.toJava should exist
+        path should exist
     }
   }
 
@@ -572,11 +572,11 @@ class FetchItemSpec extends TestSupportFixture
     val bag = fetchBagV0()
     val x = bag.data / "x"
 
-    x.toJava shouldNot exist
+    x shouldNot exist
 
     inside(bag.replaceFetchItemWithFile(FetchItem(lipsum4URL, 12L, x))) {
       case Success(_) =>
-        x.toJava should exist
+        x should exist
     }
   }
 
@@ -586,13 +586,13 @@ class FetchItemSpec extends TestSupportFixture
     val bag = fetchBagV0()
     val subU = bag.data / "sub" / "u"
 
-    subU.toJava shouldNot exist
-    subU.parent.toJava shouldNot exist
-    subU.parent.parent.toJava should exist
+    subU shouldNot exist
+    subU.parent shouldNot exist
+    subU.parent.parent should exist
 
     inside(bag.replaceFetchItemWithFile(FetchItem(lipsum1URL, 12L, subU))) {
       case Success(_) =>
-        subU.toJava should exist
+        subU should exist
     }
   }
 
@@ -614,7 +614,7 @@ class FetchItemSpec extends TestSupportFixture
     val bag = fetchBagV0()
     val u = (bag.data / "sub" createDirectory()) / "u" writeText lipsum(1)
 
-    u.toJava should exist
+    u should exist
 
     inside(bag.replaceFetchItemWithFile(FetchItem(lipsum1URL, 12L, u))) {
       case Failure(e: FileAlreadyExistsException) =>
@@ -673,7 +673,7 @@ class FetchItemSpec extends TestSupportFixture
       .getFileToChecksumMap
       .put(x, "invalid-checksum")
 
-    x.toJava shouldNot exist
+    x shouldNot exist
 
     val fetchItem = FetchItem(lipsum4URL, 12L, x)
     inside(bag.replaceFetchItemWithFile(fetchItem)) {
@@ -685,7 +685,7 @@ class FetchItemSpec extends TestSupportFixture
           "metadata",
         )
         bag.fetchFiles should contain(fetchItem)
-        x.toJava shouldNot exist
+        x shouldNot exist
     }
   }
 }

--- a/src/test/scala/nl/knaw/dans/bag/v0/ManifestSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/ManifestSpec.scala
@@ -52,11 +52,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / "path" / "to" / "file-copy.txt"
       val dest = relativeDest(bag.data)
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       addPayloadFile(bag)(file)(relativeDest) shouldBe a[Success[_]]
 
-      dest.toJava should exist
+      dest should exist
       dest.contentAsString shouldBe file.contentAsString
       dest.sha1 shouldBe file.sha1
     }
@@ -93,14 +93,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / ".." / ".." / "path" / "to" / "file-copy.txt"
       val dest = relativeDest(bag.data)
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addPayloadFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message s"pathInData '$dest' is supposed to point to a file that is a child of the bag/data directory"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
 
     it should "fail when the destination already exists" in {
@@ -109,14 +109,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / ".." / ".." / "path" / "to" / "file-copy.txt"
       val dest = relativeDest(bag.data) createIfNotExists (createParents = true) writeText lipsum(1)
 
-      dest.toJava should exist
+      dest should exist
 
       inside(addPayloadFile(bag)(file)(relativeDest)) {
         case Failure(e: FileAlreadyExistsException) =>
           e should have message dest.toString
       }
 
-      dest.toJava should exist
+      dest should exist
       dest.contentAsString shouldBe lipsum(1)
     }
 
@@ -126,7 +126,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / "x"
       val dest = relativeDest(bag.data)
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
       bag.fetchFiles.map(_.file) contains dest
       bag.payloadManifests(ChecksumAlgorithm.SHA1) should contain key dest
       val sha1Before = bag.payloadManifests(ChecksumAlgorithm.SHA1)(dest)
@@ -136,7 +136,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
         case Failure(e: FileAlreadyExistsException) =>
           e should have message s"$dest: file already present in bag as a fetch file"
 
-          dest.toJava shouldNot exist
+          dest shouldNot exist
           bag.fetchFiles.map(_.file) contains dest
           bag.payloadManifests(ChecksumAlgorithm.SHA1) should contain key dest
 
@@ -171,11 +171,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val relativeDest: RelativePath = _ / "path" / "to" / "file-copy.txt"
     val dest = relativeDest(bag.data)
 
-    dest.toJava shouldNot exist
+    dest shouldNot exist
 
     file.inputStream()(bag.addPayloadFile(_, Paths.get("path/to/file-copy.txt"))) shouldBe a[Success[_]]
 
-    dest.toJava should exist
+    dest should exist
     dest.contentAsString shouldBe file.contentAsString
     dest.sha1 shouldBe file.sha1
   }
@@ -199,7 +199,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
           .map(file => dest / newDir.relativize(file).toString)
 
         forEvery(files)(file => {
-          file.toJava should exist
+          file should exist
 
           forEvery(List(ChecksumAlgorithm.SHA1, ChecksumAlgorithm.SHA256))(algo => {
             resultBag.payloadManifests(algo) should contain key file
@@ -215,11 +215,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val relativeDest: RelativePath = _ / "path" / "to" / "file-copy.txt"
     val dest = relativeDest(bag.data)
 
-    dest.toJava shouldNot exist
+    dest shouldNot exist
 
     bag.addPayloadFile(file, Paths.get("path/to/file-copy.txt")) shouldBe a[Success[_]]
 
-    dest.toJava should exist
+    dest should exist
     dest.contentAsString shouldBe file.contentAsString
     dest.sha1 shouldBe file.sha1
   }
@@ -228,11 +228,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag.data / "sub" / "u"
 
-    file.toJava should exist
+    file should exist
 
     bag.removePayloadFile(_ / "sub" / "u") shouldBe a[Success[_]]
-    file.toJava shouldNot exist
-    file.parent.toJava should exist
+    file shouldNot exist
+    file.parent should exist
   }
 
   it should "remove the removed payload file from all manifests" in {
@@ -256,18 +256,18 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
     bag.addPayloadFile(file)(_ / "path" / "to" / "file" / "a.txt") shouldBe a[Success[_]]
 
-    destination.toJava should exist
+    destination should exist
     bag.payloadManifests(ChecksumAlgorithm.SHA1) should contain key destination
 
     inside(bag.removePayloadFile(_ / "path" / "to" / "file" / "a.txt")) {
       case Success(resultBag) =>
         resultBag.payloadManifests(ChecksumAlgorithm.SHA1) shouldNot contain key destination
 
-        destination.toJava shouldNot exist
-        destination.parent.toJava shouldNot exist
-        destination.parent.parent.toJava shouldNot exist
-        destination.parent.parent.parent.toJava shouldNot exist
-        destination.parent.parent.parent.parent.toJava should exist
+        destination shouldNot exist
+        destination.parent shouldNot exist
+        destination.parent.parent shouldNot exist
+        destination.parent.parent.parent shouldNot exist
+        destination.parent.parent.parent.parent should exist
         destination.parent.parent.parent.parent shouldBe resultBag.data
     }
   }
@@ -284,7 +284,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
     inside(result) {
       case Success(resultBag) =>
-        resultBag.data.toJava should exist
+        resultBag.data should exist
         resultBag.data.children should have size 0
     }
   }
@@ -330,7 +330,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag.data / "doesnotexist.txt"
 
-    file.toJava shouldNot exist
+    file shouldNot exist
 
     inside(bag.removePayloadFile(_ / "doesnotexist.txt")) {
       case Failure(e: NoSuchFileException) =>
@@ -342,7 +342,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "bagit.txt"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag.data) shouldBe false
 
     inside(bag.removePayloadFile(_ / ".." / "bagit.txt")) {
@@ -356,7 +356,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag.data / "sub"
 
-    file.toJava should exist
+    file should exist
     file.isDirectory shouldBe true
     val checksumsBeforeCall = bag.payloadManifests
 
@@ -364,7 +364,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove directory '$file'; you can only remove files"
 
-        file.toJava should exist
+        file should exist
         file.isDirectory shouldBe true
 
         // payload manifests didn't change
@@ -376,11 +376,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag.data / "sub" / "u"
 
-    file.toJava should exist
+    file should exist
 
     bag.removePayloadFile(Paths.get("sub/u")) shouldBe a[Success[_]]
-    file.toJava shouldNot exist
-    file.parent.toJava should exist
+    file shouldNot exist
+    file.parent should exist
   }
 
   "tagManifests" should "list all entries in the tagmanifest-<alg>.txt files" in {
@@ -408,11 +408,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / "metadata" / "temp" / "file-copy.txt"
       val dest = relativeDest(bag)
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       addTagFile(bag)(file)(relativeDest) shouldBe a[Success[_]]
 
-      dest.toJava should exist
+      dest should exist
       dest.contentAsString shouldBe file.contentAsString
       dest.sha1 shouldBe file.sha1
     }
@@ -449,14 +449,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / "data" / "path" / "to" / "file-copy.txt"
       val dest = relativeDest(bag)
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addTagFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message s"cannot add a tag file like '$dest' to the bag/data directory"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
 
     it should "fail when the destination is outside the bag directory" in {
@@ -465,14 +465,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / ".." / "path" / "to" / "file-copy.txt"
       val dest = relativeDest(bag)
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addTagFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message s"cannot add a tag file like '$dest' to a place outside the bag directory"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
 
     it should "fail when the destination already exists" in {
@@ -481,7 +481,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       val relativeDest: RelativePath = _ / "metadata" / "dataset.xml"
       val dest = relativeDest(bag)
 
-      dest.toJava should exist
+      dest should exist
       val oldContent = dest.contentAsString
 
       inside(addTagFile(bag)(file)(relativeDest)) {
@@ -489,7 +489,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
           e should have message dest.toString
       }
 
-      dest.toJava should exist
+      dest should exist
       dest.contentAsString shouldBe oldContent
     }
 
@@ -501,14 +501,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
       dest.delete()
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addTagFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message "tag file 'bag-info.txt' is controlled by the library itself; you cannot add a file to this location"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
 
     it should "fail when the destination points to bag/bagit.txt, which was removed first" in {
@@ -519,14 +519,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
       dest.delete()
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addTagFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message "tag file 'bagit.txt' is controlled by the library itself; you cannot add a file to this location"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
 
     it should "fail when the destination points to bag/fetch.txt, which was removed first" in {
@@ -537,14 +537,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
       dest.delete()
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addTagFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message "tag file 'fetch.txt' is controlled by the library itself; you cannot add a file to this location"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
 
     it should "fail when the destination points to bag/manifest-XXX.txt, which was removed first" in {
@@ -555,14 +555,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
       dest.delete()
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addTagFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message "manifest files are controlled by the library itself; you cannot add a file to this location"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
 
     it should "fail when the destination points to bag/tagmanifest-XXX.txt, which was removed first" in {
@@ -573,14 +573,14 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
       dest.delete()
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
 
       inside(addTagFile(bag)(file)(relativeDest)) {
         case Failure(e: IllegalArgumentException) =>
           e should have message "tagmanifest files are controlled by the library itself; you cannot add a file to this location"
       }
 
-      dest.toJava shouldNot exist
+      dest shouldNot exist
     }
   }
 
@@ -609,11 +609,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val relativeDest: RelativePath = _ / "metadata" / "temp" / "file-copy.txt"
     val dest = relativeDest(bag)
 
-    dest.toJava shouldNot exist
+    dest shouldNot exist
 
     file.inputStream()(bag.addTagFile(_, Paths.get("metadata/temp/file-copy.txt"))) shouldBe a[Success[_]]
 
-    dest.toJava should exist
+    dest should exist
     dest.contentAsString shouldBe file.contentAsString
     dest.sha1 shouldBe file.sha1
   }
@@ -637,7 +637,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
           .map(file => dest / newDir.relativize(file).toString)
 
         forEvery(files)(file => {
-          file.toJava should exist
+          file should exist
 
           forEvery(List(ChecksumAlgorithm.SHA1, ChecksumAlgorithm.SHA256))(algo => {
             resultBag.tagManifests(algo) should contain key file
@@ -653,11 +653,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val relativeDest: RelativePath = _ / "metadata" / "temp" / "file-copy.txt"
     val dest = relativeDest(bag)
 
-    dest.toJava shouldNot exist
+    dest shouldNot exist
 
     bag.addTagFile(file, Paths.get("metadata/temp/file-copy.txt")) shouldBe a[Success[_]]
 
-    dest.toJava should exist
+    dest should exist
     dest.contentAsString shouldBe file.contentAsString
     dest.sha1 shouldBe file.sha1
   }
@@ -666,12 +666,12 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "metadata" / "dataset.xml"
 
-    file.toJava should exist
+    file should exist
 
     bag.removeTagFile(_ / "metadata" / "dataset.xml") shouldBe a[Success[_]]
-    file.toJava shouldNot exist
+    file shouldNot exist
     file.parent shouldBe bag / "metadata"
-    file.parent.toJava should exist
+    file.parent should exist
   }
 
   it should "remove the removed tag file from all manifests" in {
@@ -695,19 +695,19 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
     bag.addTagFile(file)(_ / "path" / "to" / "file" / "a.txt") shouldBe a[Success[_]]
 
-    destination.toJava should exist
+    destination should exist
     bag.tagManifests(ChecksumAlgorithm.SHA1) should contain key destination
 
     inside(bag.removeTagFile(_ / "path" / "to" / "file" / "a.txt")) {
       case Success(resultBag) =>
         resultBag.tagManifests(ChecksumAlgorithm.SHA1) shouldNot contain key destination
 
-        destination.toJava shouldNot exist
-        destination.parent.toJava shouldNot exist
-        destination.parent.parent.toJava shouldNot exist
-        destination.parent.parent.parent.toJava shouldNot exist
+        destination shouldNot exist
+        destination.parent shouldNot exist
+        destination.parent.parent shouldNot exist
+        destination.parent.parent.parent shouldNot exist
         destination.parent.parent.parent.parent shouldBe resultBag.baseDir
-        destination.parent.parent.parent.parent.toJava should exist
+        destination.parent.parent.parent.parent should exist
     }
   }
 
@@ -715,7 +715,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "doesnotexist.txt"
 
-    file.toJava shouldNot exist
+    file shouldNot exist
 
     inside(bag.removeTagFile(_ / "doesnotexist.txt")) {
       case Failure(e: NoSuchFileException) => e should have message file.toString
@@ -726,7 +726,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag.data / "x"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag.data) shouldBe true
 
     inside(bag.removeTagFile(_ / "data" / "x")) {
@@ -739,7 +739,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / ".." / "temp.txt" createIfNotExists() writeText "content of temp.txt"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag) shouldBe false
 
     inside(bag.removeTagFile(_ / ".." / "temp.txt")) {
@@ -751,7 +751,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
   it should "fail when the file to remove is the bag directory itself" in pendingUntilFixed {
     val bag = simpleBagV0()
 
-    bag.toJava should exist
+    bag.baseDir should exist
     bag.isChildOf(bag) shouldBe false // TODO why does this actually return true??? - https://github.com/pathikrit/better-files/issues/247
 
     inside(bag.removeTagFile(x => x)) {
@@ -764,7 +764,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "bag-info.txt"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag) shouldBe true
 
     inside(bag.removeTagFile(_ / "bag-info.txt")) {
@@ -777,7 +777,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "bagit.txt"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag) shouldBe true
 
     inside(bag.removeTagFile(_ / "bagit.txt")) {
@@ -790,7 +790,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = fetchBagV0()
     val file = bag / "fetch.txt"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag) shouldBe true
 
     inside(bag.removeTagFile(_ / "fetch.txt")) {
@@ -803,7 +803,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "manifest-sha1.txt"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag) shouldBe true
 
     inside(bag.removeTagFile(_ / "manifest-sha1.txt")) {
@@ -816,7 +816,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "tagmanifest-sha1.txt"
 
-    file.toJava should exist
+    file should exist
     file.isChildOf(bag) shouldBe true
 
     inside(bag.removeTagFile(_ / "tagmanifest-sha1.txt")) {
@@ -829,7 +829,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val dir = bag / "metadata"
 
-    dir.toJava should exist
+    dir should exist
     dir.isChildOf(bag) shouldBe true
 
     inside(bag.removeTagFile(_ / "metadata")) {
@@ -842,11 +842,11 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val bag = simpleBagV0()
     val file = bag / "metadata" / "dataset.xml"
 
-    file.toJava should exist
+    file should exist
 
     bag.removeTagFile(Paths.get("metadata/dataset.xml")) shouldBe a[Success[_]]
-    file.toJava shouldNot exist
+    file shouldNot exist
     file.parent shouldBe bag / "metadata"
-    file.parent.toJava should exist
+    file.parent should exist
   }
 }

--- a/src/test/scala/nl/knaw/dans/bag/v0/PathAccessorsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/PathAccessorsSpec.scala
@@ -27,7 +27,7 @@ class PathAccessorsSpec extends TestSupportFixture with TestBags {
 
   "data" should "point to the root of the bag/data directory" in {
     val bag = simpleBagV0()
-    bag.data.toJava shouldBe (bag.baseDir / "data" toJava)
+    bag.data shouldBe (bag.baseDir / "data")
     bag.data.listRecursively.toList should contain only(
       bag.data / "x",
       bag.data / "y",

--- a/src/test/scala/nl/knaw/dans/bag/v0/SaveSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/SaveSpec.scala
@@ -126,14 +126,14 @@ class SaveSpec extends TestSupportFixture
 
     // initial assumptions
     bag.fetchFiles shouldBe empty
-    fetchTxt.toJava shouldNot exist
+    fetchTxt shouldNot exist
 
     // (no) changes + save
     bag.save() shouldBe a[Success[_]]
 
     // expected results
     bag.fetchFiles shouldBe empty
-    fetchTxt.toJava shouldNot exist
+    fetchTxt shouldNot exist
 
     // validate bag
     BagVerifier.quicklyVerify(bag.locBag)
@@ -155,7 +155,7 @@ class SaveSpec extends TestSupportFixture
 
     // initial assumptions
     bag.fetchFiles shouldBe empty
-    fetchTxt.toJava shouldNot exist
+    fetchTxt shouldNot exist
 
     // changes + save
     bag.addFetchItem(lipsum1URL, _ / "some-file1.txt")
@@ -167,7 +167,7 @@ class SaveSpec extends TestSupportFixture
       fetchItem1,
       fetchItem2,
     )
-    fetchTxt.toJava should exist
+    fetchTxt should exist
     bag.baseDir should containInFetchOnly(
       fetchItem1,
       fetchItem2
@@ -201,7 +201,7 @@ class SaveSpec extends TestSupportFixture
       existingFetchItem3,
       existingFetchItem4,
     )
-    fetchTxt.toJava should exist
+    fetchTxt should exist
     bag.baseDir should containInFetchOnly(
       existingFetchItem1,
       existingFetchItem2,
@@ -221,7 +221,7 @@ class SaveSpec extends TestSupportFixture
       existingFetchItem4,
       newFetchItem,
     )
-    fetchTxt.toJava should exist
+    fetchTxt should exist
     bag.baseDir should containInFetchOnly(
       existingFetchItem1,
       existingFetchItem2,
@@ -323,7 +323,7 @@ class SaveSpec extends TestSupportFixture
       existingFetchItem3,
       existingFetchItem4,
     )
-    fetchTxt.toJava should exist
+    fetchTxt should exist
     bag.baseDir should containInFetchOnly(
       existingFetchItem1,
       existingFetchItem2,
@@ -340,7 +340,7 @@ class SaveSpec extends TestSupportFixture
 
     // expected results
     bag.fetchFiles shouldBe empty
-    fetchTxt.toJava shouldNot exist
+    fetchTxt shouldNot exist
 
     // validate bag
     BagVerifier.quicklyVerify(bag.locBag)
@@ -404,10 +404,10 @@ class SaveSpec extends TestSupportFixture
     val sha256Manifest = bag / "manifest-sha256.txt"
 
     // initial assumptions
-    sha1Manifest.toJava should exist
+    sha1Manifest should exist
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA1)(u, v, w, x, y, z)
     sha1Manifest.contentAsString should not include bag.relativize(abc).toString
-    sha256Manifest.toJava shouldNot exist
+    sha256Manifest shouldNot exist
 
     // changes + save
     val newFile = testDir / "xxx.txt" createIfNotExists (createParents = true) writeText lipsum(5)
@@ -416,7 +416,7 @@ class SaveSpec extends TestSupportFixture
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
-    sha256Manifest.toJava should exist
+    sha256Manifest should exist
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA1)(u, v, w, x, y, z, abc)
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA256)(u, v, w, x, y, z, abc)
 
@@ -443,10 +443,10 @@ class SaveSpec extends TestSupportFixture
     val sha256Manifest = bag / "manifest-sha256.txt"
 
     // initial assumptions
-    sha1Manifest.toJava should exist
+    sha1Manifest should exist
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA1)(u, v, w, x, y, z)
 
-    sha256Manifest.toJava should exist
+    sha256Manifest should exist
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA256)(u, v, w, x, y, z)
 
     // changes + save
@@ -454,9 +454,9 @@ class SaveSpec extends TestSupportFixture
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
-    sha1Manifest.toJava should exist
+    sha1Manifest should exist
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA1)(u, v, w, x, y, z)
-    sha256Manifest.toJava shouldNot exist
+    sha256Manifest shouldNot exist
 
     // validate bag
     BagVerifier.quicklyVerify(bag.locBag)
@@ -480,7 +480,7 @@ class SaveSpec extends TestSupportFixture
     val sha1Manifest = bag / "manifest-sha1.txt"
 
     // initial assumptions
-    sha1Manifest.toJava should exist
+    sha1Manifest should exist
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA1)(u, v, w, x, y, z)
 
     // changes + save
@@ -494,7 +494,7 @@ class SaveSpec extends TestSupportFixture
 
     // expected results
     bag.data.list.toList shouldBe empty
-    sha1Manifest.toJava should exist
+    sha1Manifest should exist
     bag.baseDir should containInPayloadManifestFileOnly(ChecksumAlgorithm.SHA1)()
 
     // validate bag

--- a/src/test/scala/nl/knaw/dans/bag/v0/ValidationSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/ValidationSpec.scala
@@ -23,8 +23,8 @@ class ValidationSpec extends TestSupportFixture with TestBags with FetchFileMeta
   "isComplete" should "succeed on a complete bag" in {
     val bag = simpleBagV0()
 
-    (bag / "bagit.txt").toJava should exist
-    bag.data.toJava should exist
+    (bag / "bagit.txt") should exist
+    bag.data should exist
     bag.glob("manifest-*.txt").toList should not be empty
     bag.fetchFiles shouldBe empty
 
@@ -39,10 +39,10 @@ class ValidationSpec extends TestSupportFixture with TestBags with FetchFileMeta
     lipsum3File.copyTo(bag.data / "y-old")
     lipsum4File.copyTo(bag.data / "x")
 
-    (bag / "bagit.txt").toJava should exist
-    bag.data.toJava should exist
+    (bag / "bagit.txt") should exist
+    bag.data should exist
     bag.glob("manifest-*.txt").toList should not be empty
-    every(bag.fetchFiles.map(_.file.toJava)) should exist
+    every(bag.fetchFiles.map(_.file)) should exist
 
     bag.isComplete shouldBe 'right
   }
@@ -123,8 +123,8 @@ class ValidationSpec extends TestSupportFixture with TestBags with FetchFileMeta
     val bag = simpleBagV0()
 
     // check isComplete verifications
-    (bag / "bagit.txt").toJava should exist
-    bag.data.toJava should exist
+    (bag / "bagit.txt") should exist
+    bag.data should exist
     bag.glob("manifest-*.txt").toList should not be empty
     bag.fetchFiles shouldBe empty
 
@@ -158,10 +158,10 @@ class ValidationSpec extends TestSupportFixture with TestBags with FetchFileMeta
     lipsum4File.copyTo(bag.data / "x")
 
     // check isComplete verifications
-    (bag / "bagit.txt").toJava should exist
-    bag.data.toJava should exist
+    (bag / "bagit.txt") should exist
+    bag.data should exist
     bag.glob("manifest-*.txt").toList should not be empty
-    every(bag.fetchFiles.map(_.file.toJava)) should exist
+    every(bag.fetchFiles.map(_.file)) should exist
 
     // check payload manifest verification
     forEvery(bag.payloadManifests) {


### PR DESCRIPTION
When using ScalaTest and `better.files.File` we always had to do `file.toJava should exist`, to first convert it to a `java.io.File` and then test `... should exist` on it.

When you provide the following implicit conversion, you can just write `file should exist`.

```scala
implicit def existenceOfFile[FILE <: better.files.File]: Existence[FILE] = _.exists
```

This is just similar to the rule for `java.io.File`: https://github.com/scalatest/scalatest/blob/d40d278f2bb8e73431b942d87881fb6dbab75cb9/scalatest/src/main/scala/org/scalatest/enablers/Existence.scala#L55-L58

@DANS-KNAW/easy for review