### PR TITLE
remove RelativePath

### DIFF
--- a/src/main/scala/nl/knaw/dans/bag/DansBag.scala
+++ b/src/main/scala/nl/knaw/dans/bag/DansBag.scala
@@ -210,28 +210,6 @@ trait DansBag {
    *
    * @example
    * {{{
-   *   bag.addFetchItem(url, _ / "path" / "to" / "some" / "file.txt")
-   * }}}
-   * @param url        the url where the file is to be retrieved from
-   * @param pathInData the path relative to the `bag/data` directory where the new file is virtually being placed
-   * @return this bag, with the new FetchItem
-   */
-  def addFetchItem(url: URL, pathInData: RelativePath): Try[DansBag]
-
-  /**
-   * Adds the triple (url, length, path) to the `fetch.txt`.
-   * If the path already exists in the fetch, or in the payload, an Exception will occur.
-   * The PayloadManifests are updated with the checksum of the downloaded file. The length will be calculated as well.
-   *
-   * Due to calculating the checksums for all files, as well as downloading all fetch files, this
-   * method may take some time to complete and return. It is therefore strongly advised to wrap
-   * a call to this method in a `Promise`/`Future`, `Observable` or any other desired data structure
-   * that deals with latency in a proper way.
-   *
-   * Please note that this will only be synced with `fetch.txt` and `manifest-<alg>.txt` once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
    *   bag.addFetchItem(url, Paths.get("path/to/some/file.txt"))
    * }}}
    * @param url        the url where the file is to be retrieved from
@@ -239,20 +217,6 @@ trait DansBag {
    * @return this bag, with the new FetchItem
    */
   def addFetchItem(url: URL, pathInData: Path): Try[DansBag]
-
-  /**
-   * Removes the fetchitem with this pathInData from the `fetch.txt` and the PayloadManifests.
-   *
-   * Please note that this will only be synced with `fetch.txt` and `manifest-<alg>.txt` once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
-   *   bag.removeFetchItem(_ / "path" / "to" / "some" / "file.txt")
-   * }}}
-   * @param pathInData the path relative to the `bag/data` directory of the fetchitem to be removed
-   * @return this bag, without the fetchitem
-   */
-  def removeFetchItem(pathInData: RelativePath): Try[DansBag]
 
   /**
    * Removes the fetchitem with this pathInData from the `fetch.txt` and the PayloadManifests.
@@ -301,27 +265,6 @@ trait DansBag {
    *
    * @example
    * {{{
-   *   bag.replaceFileWithFetchItem(_ / "path" / "to" / "some" / "file.txt", url)
-   * }}}
-   * @param pathInData the path in `bag/data` to the file that is included in the fetch file
-   * @param url        the `URL` through which the file will be resolved in the future
-   * @return this bag, with the added reference in the fetch file
-   */
-  def replaceFileWithFetchItem(pathInData: RelativePath, url: URL): Try[DansBag]
-
-  /**
-   * Migrates a file from the payload directory to the fetch file, where it is referenced by the
-   * given `URL`.
-   * If the resolved path of the original file does not exist in the bag, or if the resolved path is
-   * outside of the `bag/data` directory, a `Failure` is returned.
-   * The `URL` is not checked for its resolvability, nor is this method responsible for uploading
-   * the referenced file to the specific `URL`.
-   *
-   * Please note that, while the file is removed from the bag immediately, the changes to the
-   * fetch file will only be applied to the bag on the file system once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
    *   bag.replaceFileWithFetchItem(Paths.get("path/to/some/file.txt"), url)
    * }}}
    * @param pathInData the path in `bag/data` to the file that is included in the fetch file
@@ -329,32 +272,6 @@ trait DansBag {
    * @return this bag, with the added reference in the fetch file
    */
   def replaceFileWithFetchItem(pathInData: Path, url: URL): Try[DansBag]
-
-  /**
-   * Downloads a file from the list of fetch files (indicated by the relative path to `bag/data`)
-   * through the corresponding `URL` and stores it at its original place. The original reference in
-   * `fetch.txt` is removed.
-   *
-   * If the checksum(s) of the downloaded file do(es) not match the checksum(s) listed in the
-   * payload manifest(s), a `Failure` will be returned. In this case, the file is not added to the
-   * payload directory.
-   *
-   * Due to downloading the file, this method may take some time to complete and return. It is
-   * therefore strongly advised to wrap a call to this method in a `Promise`/`Future`, `Observable`
-   * or any other desired data structure that deals with latency in a proper way.
-   *
-   * Please note that this change is applied immediately and, since no changes are made to the rest
-   * of the bag, there is no need to call [[DansBag#save]] for this to have full effect.
-   *
-   * @example
-   * {{{
-   *   bag.replaceFetchItemWithFile(_ / "path" / "to" / "some" / "file.txt")
-   * }}}
-   * @param pathInData a relative path in `bag/data` that is listed in the fetch file and where the
-   *                   file is stored on file system after being downloaded
-   * @return this bag, after having downloaded the file
-   */
-  def replaceFetchItemWithFile(pathInData: RelativePath): Try[DansBag]
 
   /**
    * Downloads a file from the list of fetch files (indicated by the relative path to `bag/data`)
@@ -524,29 +441,6 @@ trait DansBag {
    *
    * @example
    * {{{
-   *   bag.addPayloadFile(inputStream)(_ / "path" / "to" / "some" / "file.txt")
-   * }}}
-   * @param inputStream the source of the new file to be added to the bag
-   * @param pathInData  the path relative to the `bag/data` directory where the new file is being placed
-   * @return this bag, with the added checksums of the new payload file
-   */
-  def addPayloadFile(inputStream: InputStream)(pathInData: RelativePath): Try[DansBag]
-
-  /**
-   * Add a payload file from an `java.io.InputStream` to the bag at the position indicated by the
-   * path relative to the `bag/data` directory. If the resolved destination of this new file already
-   * exists within the bag, or if the resolved destination is outside of the `bag/data` directory,
-   * this method will return a `scala.util.Failure`. This method also adds the checksum of the new
-   * file to all payload manifests.
-   *
-   * Please note that fetch files are also considered part of the payload files. Therefore it is not
-   * allowed to add a payload file using this method that is already declared in `fetch.txt`.
-   *
-   * Please note that, while the new file is added to the bag immediately, the changes to the
-   * payload manifests will only be applied to the bag on the file system once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
    *   bag.addPayloadFile(inputStream, Paths.get("path/to/some/file.txt"))
    * }}}
    * @param inputStream the source of the new file to be added to the bag
@@ -554,34 +448,6 @@ trait DansBag {
    * @return this bag, with the added checksums of the new payload file
    */
   def addPayloadFile(inputStream: InputStream, pathInData: Path): Try[DansBag]
-
-  /**
-   * Add a payload file to the bag at the position indicated by the path relative to the `bag/data`
-   * directory. If the resolved destination of this new file already exists within the bag, or if
-   * the resolved destination is outside of the `bag/data` directory, this method will return a
-   * `scala.util.Failure`. This method also adds the checksum of the new file to all payload manifests.
-   *
-   * When `src` is a directory, each file will in that directory will be copied into the payload directory.
-   *
-   * Please note that fetch files are also considered part of the payload files. Therefore it is not
-   * allowed to add a payload file using this method that is already declared in `fetch.txt`.
-   *
-   * Please note that, while the new file is added to the bag immediately, the changes to the
-   * payload manifests will only be applied to the bag on the file system once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
-   *   // add a single file
-   *   bag.addPayloadFile(srcFile)(_ / "path" / "to" / "some" / "file.txt")
-   *
-   *   // add a directory of files
-   *   bag.addPayloadFile(srcDir)(_ / "path" / "to" / "some" / "directory")
-   * }}}
-   * @param src        the source of the new file to be added to the bag
-   * @param pathInData the path relative to the `bag/data` directory where the new file is being placed
-   * @return this bag, with the added checksums of the new payload file
-   */
-  def addPayloadFile(src: File)(pathInData: RelativePath): Try[DansBag]
 
   /**
    * Add a payload file to the bag at the position indicated by the path relative to the `bag/data`
@@ -624,26 +490,6 @@ trait DansBag {
    *
    * @example
    * {{{
-   *   bag.removePayloadFile(_ / "path" / "to" / "some" / "file.txt")
-   * }}}
-   * @param pathInData the path to the file within `bag/data` that is being removed
-   * @return this bag, without the payload manifest entries for the removed file
-   */
-  def removePayloadFile(pathInData: RelativePath): Try[DansBag]
-
-  /**
-   * Remove the payload file (relative to the `bag/data` directory) from the bag. This also removes
-   * the related entries from all payload manifests. If the removal of this file causes a directory
-   * to be empty, it is removed from the bag as well. However, an empty `bag/data` directory is
-   * preserved.
-   * If the given file does not exist or is not inside the `bag/data` directory or it is a directory,
-   * a `scala.util.Failure` is returned.
-   *
-   * Please note that, while the file is removed from the bag immediately, the changes to the
-   * payload manifests will only be applied to the bag on the file system once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
    *   bag.removePayloadFile(Paths.get("path/to/some/file.txt"))
    * }}}
    * @param pathInData the path to the file within `bag/data` that is being removed
@@ -657,27 +503,6 @@ trait DansBag {
    * @return the mapping of tag file to its checksum, for each algorithm
    */
   def tagManifests: Map[ChecksumAlgorithm, Map[File, String]]
-
-  /**
-   * Add a tag file from an `java.io.InputStream` to the bag at the position indicated by the
-   * path relative to the bag's base directory. If the resolved destination of this new file already
-   * exists within the bag, or if the resolved destination is outside of the base directory, inside
-   * the `bag/data` directory or if it is equal to one of the reserved files (`bagit.txt`, `bag-info.txt`,
-   * `fetch.txt`, `manifest-*.txt` or `tagmanifest-*.txt`) this method will return a
-   * `scala.util.Failure`. This method also adds the checksum of the new file to all tag manifests.
-   *
-   * Please note that, while the new file is added to the bag immediately, the changes to the
-   * tag manifests will only be applied to the bag on the file system once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
-   *   bag.addTagFile(inputStream)(_ / "path" / "to" / "some" / "file.txt")
-   * }}}
-   * @param inputStream the source of the new file to be added to the bag
-   * @param pathInBag   the path relative to the bag's base directory where the new file is being placed
-   * @return this bag, with the added checksums of the new tag file
-   */
-  def addTagFile(inputStream: InputStream)(pathInBag: RelativePath): Try[DansBag]
 
   /**
    * Add a tag file from an `java.io.InputStream` to the bag at the position indicated by the
@@ -716,33 +541,6 @@ trait DansBag {
    * @example
    * {{{
    *   // add a single file
-   *   bag.addTagFile(srcFile)(_ / "path" / "to" / "some" / "file.txt")
-   *
-   *   // add a directory of files
-   *   bag.addTagFile(srcDir)(_ / "path" / "to" / "some" / "directory")
-   * }}}
-   * @param src       the source of the new file to be added to the bag
-   * @param pathInBag the path relative to the bag's base directory where the new file is being placed
-   * @return this bag, with the added checksums of the new tag file
-   */
-  def addTagFile(src: File)(pathInBag: RelativePath): Try[DansBag]
-
-  /**
-   * Add a tag file to the bag at the position indicated by the path relative to the bag's base
-   * directory. If the resolved destination of this new file already exists within the bag, or if
-   * the resolved destination is outside of the base directory, inside the `bag/data` directory or
-   * if it is equal to one of the reserved files (`bagit.txt`, `bag-info.txt`, `fetch.txt`,
-   * `manifest-*.txt` or `tagmanifest-*.txt`) this method will return a  `scala.util.Failure`.
-   * This method also adds the checksum of the new file to all tag manifests.
-   *
-   * When `src` is a directory, each file will in that directory will be copied into the payload directory.
-   *
-   * Please note that, while the new file is added to the bag immediately, the changes to the
-   * tag manifests will only be applied to the bag on the file system once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
-   *   // add a single file
    *   bag.addTagFile(srcFile, Paths.get("path/to/some/file.txt"))
    *
    *   // add a directory of files
@@ -753,26 +551,6 @@ trait DansBag {
    * @return this bag, with the added checksums of the new tag file
    */
   def addTagFile(src: File, pathInBag: Path): Try[DansBag]
-
-  /**
-   * Remove the tag file (relative to the bag's base directory) from the bag. This also removes
-   * the related entries from all tag manifests. If the removal of this file causes a directory
-   * to be empty, it is removed from the bag as well.
-   * If the given file does not exist, or is inside the `bag/data` directory, outside/equal to the
-   * base directory, or is a directory, or is one of the reserved files (`bagit.txt`, `bag-info.txt`,
-   * `fetch.txt`, `manifest-*.txt` or `tagmanifest-*.txt`) a `scala.util.Failure` is returned.
-   *
-   * Please note that, while the file is removed from the bag immediately, the changes to the
-   * tag manifests will only be applied to the bag on the file system once [[DansBag#save]] is called.
-   *
-   * @example
-   * {{{
-   *   bag.removeTagFile(_ / "path" / "to" / "some" / "file.txt")
-   * }}}
-   * @param pathInBag the path to the file within the bag's base directory that is being removed
-   * @return this bag, without the tag manifest entries for the removed file
-   */
-  def removeTagFile(pathInBag: RelativePath): Try[DansBag]
 
   /**
    * Remove the tag file (relative to the bag's base directory) from the bag. This also removes

--- a/src/main/scala/nl/knaw/dans/bag/package.scala
+++ b/src/main/scala/nl/knaw/dans/bag/package.scala
@@ -23,7 +23,5 @@ import scala.language.implicitConversions
 
 package object bag {
 
-  type RelativePath = File => File
-
   implicit def betterFileToPath(file: File): Path = file.path
 }

--- a/src/test/scala/nl/knaw/dans/bag/fixtures/FetchFileMetadata.scala
+++ b/src/test/scala/nl/knaw/dans/bag/fixtures/FetchFileMetadata.scala
@@ -16,9 +16,9 @@
 package nl.knaw.dans.bag.fixtures
 
 import java.net.URL
+import java.nio.file.{ Path, Paths }
 
 import better.files.File
-import nl.knaw.dans.bag.RelativePath
 
 trait FetchFileMetadata {
   this: TestSupportFixture =>
@@ -31,7 +31,7 @@ trait FetchFileMetadata {
   val lipsum1URL: URL = new URL("https://raw.githubusercontent.com/rvanheest-DANS-KNAW/" +
     "dans-bag-lib/c8681a5932e4081dfec95680abefc9a07740a97a/src/test/resources/fetch-files/" +
     "lipsum1.txt")
-  val lipsum1Dest: RelativePath = _ / "sub" / "u"
+  val lipsum1Dest: Path = Paths.get("sub/u")
   val lipsum1Md5: String = "82d227831f4a3dda60e0c7c3506fa6db"
   val lipsum1Sha1: String = "33f7f7bc4d15e7749a7bace2ff57431aec260491"
   val lipsum1Sha256: String = "0aecd2e3362b4a3f5ac2f7bd048bab000ad67ae7a0b1d5cf5969e2aba09dbf10"
@@ -43,7 +43,7 @@ trait FetchFileMetadata {
   val lipsum2URL: URL = new URL("https://raw.githubusercontent.com/rvanheest-DANS-KNAW/" +
     "dans-bag-lib/c8681a5932e4081dfec95680abefc9a07740a97a/src/test/resources/fetch-files/" +
     "lipsum2.txt")
-  val lipsum2Dest: RelativePath = _ / "sub" / "v"
+  val lipsum2Dest: Path = Paths.get("sub/v")
   val lipsum2Md5: String = "31b4c84b092718937e8a1c80d7c27564"
   val lipsum2Sha1: String = "7ae3025002cfd8eb40434dd7aacb60b94e367de1"
   val lipsum2Sha256: String = "79a5e42fb48304405d9c465c5b6bff3bd1115cb6e7cb34940eb16216791b2e01"
@@ -55,7 +55,7 @@ trait FetchFileMetadata {
   val lipsum3URL: URL = new URL("https://raw.githubusercontent.com/rvanheest-DANS-KNAW/" +
     "dans-bag-lib/c8681a5932e4081dfec95680abefc9a07740a97a/src/test/resources/fetch-files/" +
     "lipsum3.txt")
-  val lipsum3Dest: RelativePath = _ / "y-old"
+  val lipsum3Dest: Path = Paths.get("y-old")
   val lipsum3Md5: String = "ec90f91c350a6815e455ef24d4ccf2ae"
   val lipsum3Sha1: String = "a98762acfd57cadd6c5ce143fe94fec46ff36d0c"
   val lipsum3Sha256: String = "b12a3260c2837d62edb2209d6199b91b7653a4dc1200d8335066e333128f01cb"
@@ -67,7 +67,7 @@ trait FetchFileMetadata {
   val lipsum4URL: URL = new URL("https://raw.githubusercontent.com/rvanheest-DANS-KNAW/" +
     "dans-bag-lib/c8681a5932e4081dfec95680abefc9a07740a97a/src/test/resources/fetch-files/" +
     "lipsum4.txt")
-  val lipsum4Dest: RelativePath = _ / "x"
+  val lipsum4Dest: Path = Paths.get("x")
   val lipsum4Md5: String = "bcbcedce7cf3849ca33bf2266ce1a39f"
   val lipsum4Sha1: String = "69ce0ab59d166a3ebccb0dca3709378e41fe79f6"
   val lipsum4Sha256: String = "4fcc40f66613006fe940380962c15356c2902de14ff0d55a7f8c794c8b4376ca"

--- a/src/test/scala/nl/knaw/dans/bag/v0/ManifestSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/ManifestSpec.scala
@@ -16,11 +16,11 @@
 package nl.knaw.dans.bag.v0
 
 import java.io.IOException
-import java.nio.file.{ FileAlreadyExistsException, NoSuchFileException, Paths }
+import java.nio.file.{ FileAlreadyExistsException, NoSuchFileException, Path, Paths }
 
 import better.files.File
+import nl.knaw.dans.bag.ChecksumAlgorithm
 import nl.knaw.dans.bag.fixtures.{ BagMatchers, Lipsum, TestBags, TestSupportFixture }
-import nl.knaw.dans.bag.{ ChecksumAlgorithm, RelativePath }
 
 import scala.language.existentials
 import scala.util.{ Failure, Success, Try }
@@ -45,12 +45,12 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     })
   }
 
-  def addPayloadFile(addPayloadFile: DansV0Bag => File => RelativePath => Try[DansV0Bag]): Unit = {
+  def addPayloadFile(addPayloadFile: DansV0Bag => File => Path => Try[DansV0Bag]): Unit = {
     it should "copy the new file into the bag" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "path" / "to" / "file-copy.txt"
-      val dest = relativeDest(bag.data)
+      val relativeDest = Paths.get("path/to/file-copy.txt")
+      val dest = bag.data / relativeDest.toString
 
       dest shouldNot exist
 
@@ -64,8 +64,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "add the checksum for all algorithms in the bag to the payload manifest" in {
       val bag = multipleManifestsBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "path" / "to" / "file-copy.txt"
-      val dest = relativeDest(bag.data)
+      val relativeDest = Paths.get("path/to/file-copy.txt")
+      val dest = bag.data / relativeDest.toString
 
       bag.payloadManifestAlgorithms should contain only(
         ChecksumAlgorithm.SHA1,
@@ -90,8 +90,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination is outside the bag/data directory" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / ".." / ".." / "path" / "to" / "file-copy.txt"
-      val dest = relativeDest(bag.data)
+      val relativeDest = Paths.get("../../path/to/file-copy.txt")
+      val dest = bag.data / relativeDest.toString
 
       dest shouldNot exist
 
@@ -106,8 +106,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination already exists" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / ".." / ".." / "path" / "to" / "file-copy.txt"
-      val dest = relativeDest(bag.data) createIfNotExists (createParents = true) writeText lipsum(1)
+      val relativeDest = Paths.get("../../path/to/file-copy.txt")
+      val dest = (bag.data / relativeDest.toString) createIfNotExists (createParents = true) writeText lipsum(1)
 
       dest should exist
 
@@ -123,8 +123,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination is already mentioned in the fetch file" in {
       val bag = fetchBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "x"
-      val dest = relativeDest(bag.data)
+      val relativeDest = Paths.get("x")
+      val dest = bag.data / relativeDest.toString
 
       dest shouldNot exist
       bag.fetchFiles.map(_.file) contains dest
@@ -146,8 +146,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     }
   }
 
-  "addPayloadFile with InputStream and RelativePath" should behave like addPayloadFile(
-    bag => file => relativeDest => file.inputStream()(bag.addPayloadFile(_)(relativeDest))
+  "addPayloadFile with InputStream" should behave like addPayloadFile(
+    bag => file => path => file.inputStream()(bag.addPayloadFile(_, path))
   )
 
   it should "fail when the given file is a directory" in {
@@ -157,30 +157,15 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     newDir / "file2.txt" createIfNotExists() writeText lipsum(2)
     newDir / "sub" / "file3.txt" createIfNotExists (createParents = true) writeText lipsum(3)
     newDir / "sub" / "subsub" / "file4.txt" createIfNotExists (createParents = true) writeText lipsum(4)
-    val relativeDest: RelativePath = _ / "path" / "to" / "newDir"
+    val relativeDest = Paths.get("path/to/newDir")
 
-    inside(newDir.inputStream()(bag.addPayloadFile(_)(relativeDest))) {
+    inside(newDir.inputStream()(bag.addPayloadFile(_, relativeDest))) {
       case Failure(e: IOException) =>
         e should have message "Is a directory"
     }
   }
 
-  "addPayloadFile with InputStream and java.nio.file.Path" should "forward to the overload with RelativePath" in {
-    val bag = simpleBagV0()
-    val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-    val relativeDest: RelativePath = _ / "path" / "to" / "file-copy.txt"
-    val dest = relativeDest(bag.data)
-
-    dest shouldNot exist
-
-    file.inputStream()(bag.addPayloadFile(_, Paths.get("path/to/file-copy.txt"))) shouldBe a[Success[_]]
-
-    dest should exist
-    dest.contentAsString shouldBe file.contentAsString
-    dest.sha1 shouldBe file.sha1
-  }
-
-  "addPayloadFile with File and RelativePath" should behave like addPayloadFile(_.addPayloadFile)
+  "addPayloadFile with File" should behave like addPayloadFile(bag => file => bag.addPayloadFile(file, _))
 
   it should "recursively add the files and folders in the directory to the bag" in {
     val bag = multipleManifestsBagV0()
@@ -190,10 +175,10 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val file3 = newDir / "sub1" / "file3.txt" createIfNotExists (createParents = true) writeText lipsum(3)
     val file4 = newDir / "sub1" / "sub1sub" / "file4.txt" createIfNotExists (createParents = true) writeText lipsum(4)
     val file5 = newDir / "sub2" / "file4.txt" createIfNotExists (createParents = true) writeText lipsum(5)
-    val relativeDest: RelativePath = _ / "path" / "to" / "newDir"
-    val dest = relativeDest(bag.data)
+    val relativeDest = Paths.get("path/to/newDir")
+    val dest = bag.data / relativeDest.toString
 
-    inside(bag.addPayloadFile(newDir)(relativeDest)) {
+    inside(bag.addPayloadFile(newDir, relativeDest)) {
       case Success(resultBag) =>
         val files = Set(file1, file2, file3, file4, file5)
           .map(file => dest / newDir.relativize(file).toString)
@@ -209,28 +194,13 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     }
   }
 
-  "addPayloadFile with File and java.nio.file.Path" should "forward to the overload with RelativePath" in {
-    val bag = simpleBagV0()
-    val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-    val relativeDest: RelativePath = _ / "path" / "to" / "file-copy.txt"
-    val dest = relativeDest(bag.data)
-
-    dest shouldNot exist
-
-    bag.addPayloadFile(file, Paths.get("path/to/file-copy.txt")) shouldBe a[Success[_]]
-
-    dest should exist
-    dest.contentAsString shouldBe file.contentAsString
-    dest.sha1 shouldBe file.sha1
-  }
-
-  "removePayloadFile with Relativepath" should "remove a payload file from the bag" in {
+  "removePayloadFile" should "remove a payload file from the bag" in {
     val bag = simpleBagV0()
     val file = bag.data / "sub" / "u"
 
     file should exist
 
-    bag.removePayloadFile(_ / "sub" / "u") shouldBe a[Success[_]]
+    bag.removePayloadFile(Paths.get("sub/u")) shouldBe a[Success[_]]
     file shouldNot exist
     file.parent should exist
   }
@@ -242,7 +212,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     bag.payloadManifests(ChecksumAlgorithm.SHA1) should contain key file
     bag.payloadManifests(ChecksumAlgorithm.SHA256) should contain key file
 
-    inside(bag.removePayloadFile(_ / "x")) {
+    inside(bag.removePayloadFile(Paths.get("x"))) {
       case Success(resultBag) =>
         resultBag.payloadManifests(ChecksumAlgorithm.SHA1) shouldNot contain key file
         resultBag.payloadManifests(ChecksumAlgorithm.SHA256) shouldNot contain key file
@@ -254,12 +224,12 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val file = testDir / "a.txt" createIfNotExists (createParents = true) writeText "content of file a"
     val destination = bag.data / "path" / "to" / "file" / "a.txt"
 
-    bag.addPayloadFile(file)(_ / "path" / "to" / "file" / "a.txt") shouldBe a[Success[_]]
+    bag.addPayloadFile(file, Paths.get("path/to/file/a.txt")) shouldBe a[Success[_]]
 
     destination should exist
     bag.payloadManifests(ChecksumAlgorithm.SHA1) should contain key destination
 
-    inside(bag.removePayloadFile(_ / "path" / "to" / "file" / "a.txt")) {
+    inside(bag.removePayloadFile(Paths.get("path/to/file/a.txt"))) {
       case Success(resultBag) =>
         resultBag.payloadManifests(ChecksumAlgorithm.SHA1) shouldNot contain key destination
 
@@ -275,12 +245,12 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
   it should "keep an empty bag/data directory if all files are removed from the bag" in {
     val bag = simpleBagV0()
 
-    val result = bag.removePayloadFile(_ / "x")
-      .flatMap(_.removePayloadFile(_ / "y"))
-      .flatMap(_.removePayloadFile(_ / "z"))
-      .flatMap(_.removePayloadFile(_ / "sub" / "u"))
-      .flatMap(_.removePayloadFile(_ / "sub" / "v"))
-      .flatMap(_.removePayloadFile(_ / "sub" / "w"))
+    val result = bag.removePayloadFile(Paths.get("x"))
+      .flatMap(_.removePayloadFile(Paths.get("y")))
+      .flatMap(_.removePayloadFile(Paths.get("z")))
+      .flatMap(_.removePayloadFile(Paths.get("sub/u")))
+      .flatMap(_.removePayloadFile(Paths.get("sub/v")))
+      .flatMap(_.removePayloadFile(Paths.get("sub/w")))
 
     inside(result) {
       case Success(resultBag) =>
@@ -309,12 +279,12 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
       })
     })
 
-    val result = bag.removePayloadFile(_ / "x")
-      .flatMap(_.removePayloadFile(_ / "y"))
-      .flatMap(_.removePayloadFile(_ / "z"))
-      .flatMap(_.removePayloadFile(_ / "sub" / "u"))
-      .flatMap(_.removePayloadFile(_ / "sub" / "v"))
-      .flatMap(_.removePayloadFile(_ / "sub" / "w"))
+    val result = bag.removePayloadFile(Paths.get("x"))
+      .flatMap(_.removePayloadFile(Paths.get("y")))
+      .flatMap(_.removePayloadFile(Paths.get("z")))
+      .flatMap(_.removePayloadFile(Paths.get("sub/u")))
+      .flatMap(_.removePayloadFile(Paths.get("sub/v")))
+      .flatMap(_.removePayloadFile(Paths.get("sub/w")))
 
     inside(result) {
       case Success(resultBag) =>
@@ -332,7 +302,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
     file shouldNot exist
 
-    inside(bag.removePayloadFile(_ / "doesnotexist.txt")) {
+    inside(bag.removePayloadFile(Paths.get("doesnotexist.txt"))) {
       case Failure(e: NoSuchFileException) =>
         e should have message file.toString
     }
@@ -345,7 +315,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag.data) shouldBe false
 
-    inside(bag.removePayloadFile(_ / ".." / "bagit.txt")) {
+    inside(bag.removePayloadFile(Paths.get("../bagit.txt"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"pathInData '$file' is supposed to point to a file that is a " +
           s"child of the bag/data directory"
@@ -360,7 +330,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file.isDirectory shouldBe true
     val checksumsBeforeCall = bag.payloadManifests
 
-    inside(bag.removePayloadFile(_ / "sub")) {
+    inside(bag.removePayloadFile(Paths.get("sub"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove directory '$file'; you can only remove files"
 
@@ -370,17 +340,6 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
         // payload manifests didn't change
         bag.payloadManifests shouldBe checksumsBeforeCall
     }
-  }
-
-  "removePayloadFile with java.nio.file.Path" should "forward to the overload with RelativePath" in {
-    val bag = simpleBagV0()
-    val file = bag.data / "sub" / "u"
-
-    file should exist
-
-    bag.removePayloadFile(Paths.get("sub/u")) shouldBe a[Success[_]]
-    file shouldNot exist
-    file.parent should exist
   }
 
   "tagManifests" should "list all entries in the tagmanifest-<alg>.txt files" in {
@@ -401,12 +360,12 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     })
   }
 
-  def addTagFile(addTagFile: DansV0Bag => File => RelativePath => Try[DansV0Bag]): Unit = {
+  def addTagFile(addTagFile: DansV0Bag => File => Path => Try[DansV0Bag]): Unit = {
     it should "copy the new file into the bag" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "metadata" / "temp" / "file-copy.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("metadata/temp/file-copy.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest shouldNot exist
 
@@ -420,8 +379,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "add the checksum for all algorithms in the bag to the tag manifests" in {
       val bag = multipleManifestsBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "metadata" / "temp" / "file-copy.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("metadata/temp/file-copy.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       bag.tagManifestAlgorithms should contain only(
         ChecksumAlgorithm.SHA1,
@@ -446,8 +405,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination is inside the bag/data directory" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "data" / "path" / "to" / "file-copy.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("data/path/to/file-copy.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest shouldNot exist
 
@@ -462,8 +421,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination is outside the bag directory" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / ".." / "path" / "to" / "file-copy.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("../path/to/file-copy.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest shouldNot exist
 
@@ -478,8 +437,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination already exists" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "metadata" / "dataset.xml"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("metadata/dataset.xml")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest should exist
       val oldContent = dest.contentAsString
@@ -496,8 +455,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination points to bag/bag-info.txt, which was removed first" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "bag-info.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("bag-info.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest.delete()
 
@@ -514,8 +473,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination points to bag/bagit.txt, which was removed first" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "bagit.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("bagit.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest.delete()
 
@@ -532,8 +491,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination points to bag/fetch.txt, which was removed first" in {
       val bag = fetchBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "fetch.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("fetch.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest.delete()
 
@@ -550,8 +509,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination points to bag/manifest-XXX.txt, which was removed first" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "manifest-sha1.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("manifest-sha1.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest.delete()
 
@@ -568,8 +527,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     it should "fail when the destination points to bag/tagmanifest-XXX.txt, which was removed first" in {
       val bag = simpleBagV0()
       val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-      val relativeDest: RelativePath = _ / "tagmanifest-sha1.txt"
-      val dest = relativeDest(bag)
+      val relativeDest = Paths.get("tagmanifest-sha1.txt")
+      val dest = bag.baseDir / relativeDest.toString
 
       dest.delete()
 
@@ -584,8 +543,8 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     }
   }
 
-  "addTagFile with InputStream and RelativePath" should behave like addTagFile(
-    bag => file => relativeDest => file.inputStream()(bag.addTagFile(_)(relativeDest))
+  "addTagFile with InputStream" should behave like addTagFile(
+    bag => file => relativeDest => file.inputStream()(bag.addTagFile(_, relativeDest))
   )
 
   it should "fail when the given file is a directory" in {
@@ -595,30 +554,15 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     newDir / "file2.txt" createIfNotExists() writeText lipsum(2)
     newDir / "sub" / "file3.txt" createIfNotExists (createParents = true) writeText lipsum(3)
     newDir / "sub" / "subsub" / "file4.txt" createIfNotExists (createParents = true) writeText lipsum(4)
-    val relativeDest: RelativePath = _ / "path" / "to" / "newDir"
+    val relativeDest = Paths.get("path/to/newDir")
 
-    inside(newDir.inputStream()(bag.addTagFile(_)(relativeDest))) {
+    inside(newDir.inputStream()(bag.addTagFile(_, relativeDest))) {
       case Failure(e: IOException) =>
         e should have message "Is a directory"
     }
   }
 
-  "addTagFile with InputStream and java.nio.file.Path" should "forward to the overload with RelativePath" in {
-    val bag = simpleBagV0()
-    val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-    val relativeDest: RelativePath = _ / "metadata" / "temp" / "file-copy.txt"
-    val dest = relativeDest(bag)
-
-    dest shouldNot exist
-
-    file.inputStream()(bag.addTagFile(_, Paths.get("metadata/temp/file-copy.txt"))) shouldBe a[Success[_]]
-
-    dest should exist
-    dest.contentAsString shouldBe file.contentAsString
-    dest.sha1 shouldBe file.sha1
-  }
-
-  "addTagFile with File and RelativePath" should behave like addTagFile(_.addTagFile)
+  "addTagFile with File" should behave like addTagFile(bag => file => bag.addTagFile(file, _))
 
   it should "recursively add the files and folders in the directory to the bag" in {
     val bag = multipleManifestsBagV0()
@@ -628,10 +572,10 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val file3 = newDir / "sub1" / "file3.txt" createIfNotExists (createParents = true) writeText lipsum(3)
     val file4 = newDir / "sub1" / "sub1sub" / "file4.txt" createIfNotExists (createParents = true) writeText lipsum(4)
     val file5 = newDir / "sub2" / "file4.txt" createIfNotExists (createParents = true) writeText lipsum(5)
-    val relativeDest: RelativePath = _ / "path" / "to" / "newDir"
-    val dest = relativeDest(bag)
+    val relativeDest = Paths.get("path/to/newDir")
+    val dest = bag.baseDir / relativeDest.toString
 
-    inside(bag.addTagFile(newDir)(relativeDest)) {
+    inside(bag.addTagFile(newDir, relativeDest)) {
       case Success(resultBag) =>
         val files = Set(file1, file2, file3, file4, file5)
           .map(file => dest / newDir.relativize(file).toString)
@@ -647,28 +591,13 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     }
   }
 
-  "addTagFile with File and java.nio.file.Path" should "forward to the overload with RelativePath" in {
-    val bag = simpleBagV0()
-    val file = testDir / "file.txt" createIfNotExists() writeText lipsum(3)
-    val relativeDest: RelativePath = _ / "metadata" / "temp" / "file-copy.txt"
-    val dest = relativeDest(bag)
-
-    dest shouldNot exist
-
-    bag.addTagFile(file, Paths.get("metadata/temp/file-copy.txt")) shouldBe a[Success[_]]
-
-    dest should exist
-    dest.contentAsString shouldBe file.contentAsString
-    dest.sha1 shouldBe file.sha1
-  }
-
-  "removeTagFile with RelativePath" should "remove a tag file from the bag" in {
+  "removeTagFile" should "remove a tag file from the bag" in {
     val bag = simpleBagV0()
     val file = bag / "metadata" / "dataset.xml"
 
     file should exist
 
-    bag.removeTagFile(_ / "metadata" / "dataset.xml") shouldBe a[Success[_]]
+    bag.removeTagFile(Paths.get("metadata/dataset.xml")) shouldBe a[Success[_]]
     file shouldNot exist
     file.parent shouldBe bag / "metadata"
     file.parent should exist
@@ -681,7 +610,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     bag.tagManifests(ChecksumAlgorithm.SHA1) should contain key file
     bag.tagManifests(ChecksumAlgorithm.SHA256) should contain key file
 
-    inside(bag.removeTagFile(_ / "metadata" / "dataset.xml")) {
+    inside(bag.removeTagFile(Paths.get("metadata/dataset.xml"))) {
       case Success(resultBag) =>
         resultBag.tagManifests(ChecksumAlgorithm.SHA1) shouldNot contain key file
         resultBag.tagManifests(ChecksumAlgorithm.SHA256) shouldNot contain key file
@@ -693,12 +622,12 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     val file = testDir / "a.txt" createIfNotExists (createParents = true) writeText "content of file a"
     val destination = bag / "path" / "to" / "file" / "a.txt"
 
-    bag.addTagFile(file)(_ / "path" / "to" / "file" / "a.txt") shouldBe a[Success[_]]
+    bag.addTagFile(file, Paths.get("path/to/file/a.txt")) shouldBe a[Success[_]]
 
     destination should exist
     bag.tagManifests(ChecksumAlgorithm.SHA1) should contain key destination
 
-    inside(bag.removeTagFile(_ / "path" / "to" / "file" / "a.txt")) {
+    inside(bag.removeTagFile(Paths.get("path/to/file/a.txt"))) {
       case Success(resultBag) =>
         resultBag.tagManifests(ChecksumAlgorithm.SHA1) shouldNot contain key destination
 
@@ -717,7 +646,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
 
     file shouldNot exist
 
-    inside(bag.removeTagFile(_ / "doesnotexist.txt")) {
+    inside(bag.removeTagFile(Paths.get("doesnotexist.txt"))) {
       case Failure(e: NoSuchFileException) => e should have message file.toString
     }
   }
@@ -729,7 +658,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag.data) shouldBe true
 
-    inside(bag.removeTagFile(_ / "data" / "x")) {
+    inside(bag.removeTagFile(Paths.get("data/x"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove '$file' since it is a child of the bag/data directory"
     }
@@ -742,7 +671,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag) shouldBe false
 
-    inside(bag.removeTagFile(_ / ".." / "temp.txt")) {
+    inside(bag.removeTagFile(Paths.get("../temp.txt"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove '$file' since it is not a child of the bag directory"
     }
@@ -754,7 +683,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     bag.baseDir should exist
     bag.isChildOf(bag) shouldBe false // TODO why does this actually return true??? - https://github.com/pathikrit/better-files/issues/247
 
-    inside(bag.removeTagFile(x => x)) {
+    inside(bag.removeTagFile(Paths.get(""))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message "cannot remove the whole bag"
     }
@@ -767,7 +696,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag) shouldBe true
 
-    inside(bag.removeTagFile(_ / "bag-info.txt")) {
+    inside(bag.removeTagFile(Paths.get("bag-info.txt"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove bag specific file '$file'"
     }
@@ -780,7 +709,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag) shouldBe true
 
-    inside(bag.removeTagFile(_ / "bagit.txt")) {
+    inside(bag.removeTagFile(Paths.get("bagit.txt"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove bag specific file '$file'"
     }
@@ -793,7 +722,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag) shouldBe true
 
-    inside(bag.removeTagFile(_ / "fetch.txt")) {
+    inside(bag.removeTagFile(Paths.get("fetch.txt"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove bag specific file '$file'"
     }
@@ -806,7 +735,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag) shouldBe true
 
-    inside(bag.removeTagFile(_ / "manifest-sha1.txt")) {
+    inside(bag.removeTagFile(Paths.get("manifest-sha1.txt"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove manifest file '$file'"
     }
@@ -819,7 +748,7 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     file should exist
     file.isChildOf(bag) shouldBe true
 
-    inside(bag.removeTagFile(_ / "tagmanifest-sha1.txt")) {
+    inside(bag.removeTagFile(Paths.get("tagmanifest-sha1.txt"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove tagmanifest file '$file'"
     }
@@ -832,21 +761,9 @@ class ManifestSpec extends TestSupportFixture with TestBags with BagMatchers wit
     dir should exist
     dir.isChildOf(bag) shouldBe true
 
-    inside(bag.removeTagFile(_ / "metadata")) {
+    inside(bag.removeTagFile(Paths.get("metadata"))) {
       case Failure(e: IllegalArgumentException) =>
         e should have message s"cannot remove directory '$dir'; you can only remove files"
     }
-  }
-
-  "removeTagFile with java.nio.file.Path" should "forward to the overload with RelativePath" in {
-    val bag = simpleBagV0()
-    val file = bag / "metadata" / "dataset.xml"
-
-    file should exist
-
-    bag.removeTagFile(Paths.get("metadata/dataset.xml")) shouldBe a[Success[_]]
-    file shouldNot exist
-    file.parent shouldBe bag / "metadata"
-    file.parent should exist
   }
 }

--- a/src/test/scala/nl/knaw/dans/bag/v0/SaveSpec.scala
+++ b/src/test/scala/nl/knaw/dans/bag/v0/SaveSpec.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.bag.v0
 
 import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
 import java.util.UUID
 
 import gov.loc.repository.bagit.conformance.{ BagLinter, BagitWarning }
@@ -91,7 +92,7 @@ class SaveSpec extends TestSupportFixture
     // changes + save
     val newFile = testDir / "xxx.txt" createIfNotExists (createParents = true) writeText lipsum(5)
     val uuid = s"urn:uuid:${ UUID.randomUUID() }"
-    bag.addPayloadFile(newFile)(_ / "abc.txt")
+    bag.addPayloadFile(newFile, Paths.get("abc.txt"))
       .map(_.addBagInfo("Is-Version-Of", uuid))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
@@ -159,8 +160,8 @@ class SaveSpec extends TestSupportFixture
     fetchTxt shouldNot exist
 
     // changes + save
-    bag.addFetchItem(lipsum1URL, _ / "some-file1.txt")
-      .flatMap(_.addFetchItem(lipsum2URL, _ / "some-file2.txt"))
+    bag.addFetchItem(lipsum1URL, Paths.get("some-file1.txt"))
+      .flatMap(_.addFetchItem(lipsum2URL, Paths.get("some-file2.txt")))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
@@ -211,7 +212,7 @@ class SaveSpec extends TestSupportFixture
     )
 
     // changes + save
-    bag.addFetchItem(newFetchItem.url, _ / "some-file1.txt")
+    bag.addFetchItem(newFetchItem.url, Paths.get("some-file1.txt"))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
@@ -255,7 +256,7 @@ class SaveSpec extends TestSupportFixture
     (bag / "manifest-sha256.txt").contentAsString should not include s"$lipsum5Sha256  ${ bag.baseDir.relativize(newFetchItem.file) }"
 
     // changes + save
-    bag.addFetchItem(newFetchItem.url, _ / "some-file.txt")
+    bag.addFetchItem(newFetchItem.url, Paths.get("some-file.txt"))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
@@ -289,7 +290,7 @@ class SaveSpec extends TestSupportFixture
     (bag / "tagmanifest-sha256.txt").contentAsString should not include "fetch.txt"
 
     // changes + save
-    bag.addFetchItem(newFetchItem.url, _ / "some-file.txt")
+    bag.addFetchItem(newFetchItem.url, Paths.get("some-file.txt"))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
@@ -373,8 +374,8 @@ class SaveSpec extends TestSupportFixture
 
     // changes + save
     val newFile = testDir / "xxx.txt" createIfNotExists (createParents = true) writeText lipsum(5)
-    bag.addPayloadFile(newFile)(_ / "abc.txt")
-      .flatMap(_.removePayloadFile(_ / "y"))
+    bag.addPayloadFile(newFile, Paths.get("abc.txt"))
+      .flatMap(_.removePayloadFile(Paths.get("y")))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
@@ -413,7 +414,7 @@ class SaveSpec extends TestSupportFixture
     // changes + save
     val newFile = testDir / "xxx.txt" createIfNotExists (createParents = true) writeText lipsum(5)
     bag.addPayloadManifestAlgorithm(ChecksumAlgorithm.SHA256)
-      .flatMap(_.addPayloadFile(newFile)(_ / "abc.txt"))
+      .flatMap(_.addPayloadFile(newFile, Paths.get("abc.txt")))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
@@ -540,7 +541,7 @@ class SaveSpec extends TestSupportFixture
     )
 
     // changes + save
-    bag.addPayloadFile(newFileSrc)(_ => newFile)
+    bag.addPayloadFile(newFileSrc, bag.data.relativize(newFile))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results
@@ -576,7 +577,7 @@ class SaveSpec extends TestSupportFixture
 
     // changes + save
     bag.addTagManifestAlgorithm(ChecksumAlgorithm.MD5)
-      .flatMap(_.addTagFile(newFileSrc)(_ => newFile))
+      .flatMap(_.addTagFile(newFileSrc, bag.baseDir.relativize(newFile)))
       .flatMap(_.save()) shouldBe a[Success[_]]
 
     // expected results


### PR DESCRIPTION
As preparation for an improved version of #42, we decided to remove `RelativePath` in favor of `java.nio.file.Path`. The means a breaking change in the code and likely some code that has to be modified by the users of the `RelativePath` overloaded methods in the `DansBag` interface.

@DANS-KNAW/easy for review