### PR TITLE
like EASY-2039 upgrade of better.files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <dependency>
             <groupId>com.github.pathikrit</groupId>
             <artifactId>better-files_2.12</artifactId>
+            <version>3.8.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
+++ b/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
@@ -21,7 +21,7 @@ import java.nio.charset.Charset
 import java.nio.file.{ AtomicMoveNotSupportedException, FileAlreadyExistsException, NoSuchFileException, Path, StandardCopyOption, Files => jFiles }
 import java.util.{ UUID, Set => jSet }
 
-import better.files.{ CloseableOps, Disposable, Dispose, File }
+import better.files._
 import gov.loc.repository.bagit.creator.BagCreator
 import gov.loc.repository.bagit.domain.{ Version, Bag => LocBag, FetchItem => LocFetchItem, Manifest => LocManifest, Metadata => LocMetadata }
 import gov.loc.repository.bagit.reader.BagReader


### PR DESCRIPTION
prepares for EASY-2039 atomic moves in other modules

#### When applied it will
* allow easy-deposit-api to run its tests with an upgraded better files
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/135 must have a version conflict
