### PR TITLE
EASY-2717: add overloads for validation with ExecutorService

### DIFF
--- a/src/main/scala/nl/knaw/dans/bag/DansBag.scala
+++ b/src/main/scala/nl/knaw/dans/bag/DansBag.scala
@@ -20,6 +20,7 @@ import java.net.{ URI, URL }
 import java.nio.charset.Charset
 import java.nio.file.Path
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 
 import better.files.File
 import gov.loc.repository.bagit.domain.{ Version => LocVersion }
@@ -619,6 +620,8 @@ trait DansBag {
    */
   def isComplete: Either[String, Unit]
 
+  def isComplete(executor: ExecutorService): Either[String, Unit]
+
   /**
    * Verifies if a bag is valid.
    * According to the BagIt v16 specs, a bag is valid when:
@@ -636,6 +639,8 @@ trait DansBag {
    *         the bag is not valid)
    */
   def isValid: Either[String, Unit]
+
+  def isValid(executor: ExecutorService): Either[String, Unit]
 }
 
 object DansBag {

--- a/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
+++ b/src/main/scala/nl/knaw/dans/bag/v0/DansV0Bag.scala
@@ -19,9 +19,10 @@ import java.io.InputStream
 import java.net.{ HttpURLConnection, URI, URL, URLConnection }
 import java.nio.charset.Charset
 import java.nio.file.{ AtomicMoveNotSupportedException, FileAlreadyExistsException, NoSuchFileException, Path, StandardCopyOption, Files => jFiles }
+import java.util.concurrent.ExecutorService
 import java.util.{ UUID, Set => jSet }
 
-import better.files.{DisposeableExtensions, Disposable, Dispose, File }
+import better.files.{ Disposable, Dispose, DisposeableExtensions, File }
 import gov.loc.repository.bagit.creator.BagCreator
 import gov.loc.repository.bagit.domain.{ Version, Bag => LocBag, FetchItem => LocFetchItem, Manifest => LocManifest, Metadata => LocMetadata }
 import gov.loc.repository.bagit.reader.BagReader
@@ -675,11 +676,21 @@ class DansV0Bag private(private[v0] val locBag: LocBag) extends DansBag {
       .toEither.left.map(_.getMessage)
   }
 
+  override def isComplete(executor: ExecutorService): Either[String, Unit] = {
+    Try { new Dispose(new BagVerifier(executor)).apply(_.isComplete(this.locBag, false)) }
+      .toEither.left.map(_.getMessage)
+  }
+
   /**
    * @inheritdoc
    */
   override def isValid: Either[String, Unit] = {
     Try { new Dispose(new BagVerifier()).apply(_.isValid(this.locBag, false)) }
+      .toEither.left.map(_.getMessage)
+  }
+
+  override def isValid(executor: ExecutorService): Either[String, Unit] = {
+    Try { new Dispose(new BagVerifier(executor)).apply(_.isValid(this.locBag, false)) }
       .toEither.left.map(_.getMessage)
   }
 


### PR DESCRIPTION
fixes EASY-2717

#### When applied it will
* add overloads for `DansBag.isComplete` and `DansBag.isValid` with `ExecutorService` argument

@DANS-KNAW/easy for review